### PR TITLE
Ignore terraform.tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,8 @@ crash.log
 # Ignore any .tfvars files that are generated automatically for each Terraform run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
-#
-# example.tfvars
-test/fixtures/shared/terraform.tfvars
+
+**/*/terraform.tfvars
 
 credentials.json
 

--- a/test/fixtures/automatic_labelling/terraform.tfvars
+++ b/test/fixtures/automatic_labelling/terraform.tfvars
@@ -1,5 +1,0 @@
-project_id = "aaronlane-event-function-test"
-
-region = "us-east1"
-
-zone = "us-east1-b"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -28,8 +28,8 @@ if [ -z "${SERVICE_ACCOUNT_JSON}" ]; then
 fi
 
 export TF_VAR_project_id="${PROJECT_ID}"
-export TF_VAR_region="${REGION:-us-east4}"
-export TF_VAR_zone="${ZONE:-us-east4-a}"
+export TF_VAR_region="${REGION:-us-east1}"
+export TF_VAR_zone="${ZONE:-us-east1-b}"
 
 DELETE_AT_EXIT="$(mktemp -d)"
 finish() {


### PR DESCRIPTION
This branch ignores the erroneously included `terraform.tfvars`.