### PR TITLE
Use uniform-level access policy in GCS bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,12 +48,13 @@ data "archive_file" "main" {
 }
 
 resource "google_storage_bucket" "main" {
-  name          = coalesce(var.bucket_name, var.name)
-  force_destroy = var.bucket_force_destroy
-  location      = var.region
-  project       = var.project_id
-  storage_class = "REGIONAL"
-  labels        = var.bucket_labels
+  name               = coalesce(var.bucket_name, var.name)
+  force_destroy      = var.bucket_force_destroy
+  location           = var.region
+  project            = var.project_id
+  storage_class      = "REGIONAL"
+  labels             = var.bucket_labels
+  bucket_policy_only = true
 }
 
 resource "google_storage_bucket_object" "main" {


### PR DESCRIPTION
For the GCS bucket created to store the Cloud Function, always use uniform-level bucket access. Right now if this configuration is controlled via an org policy, you can't use this module - there are no other workarounds.

```
Error: googleapi: Error 412: Request violates constraint 'constraints/storage.uniformBucketLevelAccess', conditionNotMet

  on .terraform/modules/firestore-export/main.tf line 50, in resource "google_storage_bucket" "main":
  50: resource "google_storage_bucket" "main" {
```