### PR TITLE
Add Ingress Settings to the Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ module "localhost_function" {
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | string | n/a | yes |
 | timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
+| ingress\_settings | The ingress settings for the function | string | `"ALLOW_ALL"` | no |
+
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ resource "google_cloudfunctions_function" "main" {
   available_memory_mb = var.available_memory_mb
   timeout             = var.timeout_s
   entry_point         = var.entry_point
+  ingress_settings    = var.ingress_settings
 
   event_trigger {
     event_type = var.event_trigger["event_type"]

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,9 @@ variable "event_trigger_failure_policy_retry" {
   default     = false
   description = "A toggle to determine if the function should be retried on failure."
 }
+
+variable "ingress_settings" {
+  type        = string
+  default     = "ALLOW_ALL"
+  description = "Ingress settings for the Cloud Function"
+}


### PR DESCRIPTION
Adding `ingress_settings` variable to the Cloud Function.  A customer requested this for security purposes.