### PR TITLE
fix: constrain minimum Google provider version to 3.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.0](https://www.github.com/terraform-google-modules/terraform-google-event-function/compare/v1.2.0...v1.3.0) (2020-09-18)
 
+### ⚠ BREAKING CHANGES
+
+* Minimum Google provider version increased to [3.38.0](https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#3380-september-08-2020)
+
 
 ### Features
 

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google = ">= 3.38.0"
+  }
 }


### PR DESCRIPTION
Similar to https://github.com/terraform-google-modules/terraform-google-cloud-storage/pull/84