### PR TITLE
removed interpolation expression

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ data "null_data_source" "wait_for_files" {
   inputs = {
     # This ensures that this data resource will not be evaluated until
     # after the null_resource has been created.
-    dependent_files_id = "${null_resource.dependent_files.id}"
+    dependent_files_id = null_resource.dependent_files.id
 
     # This value gives us something to implicitly depend on
     # in the archive_file below.


### PR DESCRIPTION
Removed the interpolation expression because it was popping up a warning when running with terraform >=12.

Fixes #53.