### PR TITLE
Adding trigger_http input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "localhost_function" {
 | description | The description of the function. | string | `"Processes events."` | no |
 | entry\_point | The name of a method in the function source which will be invoked when the function is executed. | string | n/a | yes |
 | environment\_variables | A set of key/value environment variable pairs to assign to the function. | map(string) | `<map>` | no |
-| event\_trigger | A source that fires events in response to a condition in another service. | map(string) | n/a | yes |
+| event\_trigger | A source that fires events in response to a condition in another service. Either this input must be defined or the `trigger_http` input must be set to `true`. | map(string) | n/a | no |
 | event\_trigger\_failure\_policy\_retry | A toggle to determine if the function should be retried on failure. | bool | `"false"` | no |
 | files\_to\_exclude\_in\_source\_dir | Specify files to ignore when reading the source_dir | list(string) | `<list>` | no |
 | ingress\_settings | The ingress settings for the function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY. Changes to this field will recreate the cloud function. | string | `"ALLOW_ALL"` | no |
@@ -72,6 +72,7 @@ module "localhost_function" {
 | service\_account\_email | The service account to run the function as. | string | `""` | no |
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | string | n/a | yes |
+| trigger\_http | Any HTTP request (of a supported type) to the endpoint will trigger function execution. Either this input must be set to `true` or the `trigger_http` input must be defined. | bool | `"false"` | no |
 | timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
 | vpc\_connector | The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is projects/*/locations/*/connectors/*. | string | `"null"` | no |
 | vpc\_connector\_egress\_settings | The egress settings for the connector, controlling what traffic is diverted through it. Allowed values are ALL_TRAFFIC and PRIVATE_RANGES_ONLY. If unset, this field preserves the previously set value. | string | `"null"` | no |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "localhost_function" {
 | description | The description of the function. | string | `"Processes events."` | no |
 | entry\_point | The name of a method in the function source which will be invoked when the function is executed. | string | n/a | yes |
 | environment\_variables | A set of key/value environment variable pairs to assign to the function. | map(string) | `<map>` | no |
-| event\_trigger | A source that fires events in response to a condition in another service. Either this input must be defined or the `trigger_http` input must be set to `true`. | map(string) | n/a | no |
+| event\_trigger | A source that fires events in response to a condition in another service. | map(string) | `<map>` | no |
 | event\_trigger\_failure\_policy\_retry | A toggle to determine if the function should be retried on failure. | bool | `"false"` | no |
 | files\_to\_exclude\_in\_source\_dir | Specify files to ignore when reading the source_dir | list(string) | `<list>` | no |
 | ingress\_settings | The ingress settings for the function. Allowed values are ALLOW_ALL, ALLOW_INTERNAL_AND_GCLB and ALLOW_INTERNAL_ONLY. Changes to this field will recreate the cloud function. | string | `"ALLOW_ALL"` | no |
@@ -72,8 +72,8 @@ module "localhost_function" {
 | service\_account\_email | The service account to run the function as. | string | `""` | no |
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | string | n/a | yes |
-| trigger\_http | Any HTTP request (of a supported type) to the endpoint will trigger function execution. Either this input must be set to `true` or the `trigger_http` input must be defined. | bool | `"false"` | no |
 | timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
+| trigger\_http | Wheter to use HTTP trigger instead of the event trigger. | bool | `"null"` | no |
 | vpc\_connector | The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is projects/*/locations/*/connectors/*. | string | `"null"` | no |
 | vpc\_connector\_egress\_settings | The egress settings for the connector, controlling what traffic is diverted through it. Allowed values are ALL_TRAFFIC and PRIVATE_RANGES_ONLY. If unset, this field preserves the previously set value. | string | `"null"` | no |
 
@@ -81,6 +81,7 @@ module "localhost_function" {
 
 | Name | Description |
 |------|-------------|
+| https\_trigger\_url | URL which triggers function execution. |
 | name | The name of the function. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -76,15 +76,20 @@ resource "google_cloudfunctions_function" "main" {
   timeout                       = var.timeout_s
   entry_point                   = var.entry_point
   ingress_settings              = var.ingress_settings
+  trigger_http                  = var.trigger_http
   vpc_connector_egress_settings = var.vpc_connector_egress_settings
   vpc_connector                 = var.vpc_connector
 
-  event_trigger {
-    event_type = var.event_trigger["event_type"]
-    resource   = var.event_trigger["resource"]
+  dynamic "event_trigger" {
+    for_each = var.trigger_http ? [] : [1]
 
-    failure_policy {
-      retry = var.event_trigger_failure_policy_retry
+    content {
+      event_type = var.event_trigger["event_type"]
+      resource   = var.event_trigger["resource"]
+
+      failure_policy {
+        retry = var.event_trigger_failure_policy_retry
+      }
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "google_cloudfunctions_function" "main" {
   vpc_connector                 = var.vpc_connector
 
   dynamic "event_trigger" {
-    for_each = var.trigger_http ? [] : [1]
+    for_each = var.trigger_http != null ? [] : [1]
 
     content {
       event_type = var.event_trigger["event_type"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,5 +21,5 @@ output "name" {
 
 output "https_trigger_url" {
   description = "URL which triggers function execution."
-  value       = var.trigger_http ? google_cloudfunctions_function.main.https_trigger_url : ""
+  value       = var.trigger_http != null ? google_cloudfunctions_function.main.https_trigger_url : ""
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,8 @@ output "name" {
   description = "The name of the function."
   value       = google_cloudfunctions_function.main.name
 }
+
+output "https_trigger_url" {
+  description = "URL which triggers function execution."
+  value       = var.trigger_http ? google_cloudfunctions_function.main.https_trigger_url : ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,14 @@ variable "environment_variables" {
 
 variable "event_trigger" {
   type        = map(string)
+  default     = {}
   description = "A source that fires events in response to a condition in another service."
+}
+
+variable "trigger_http" {
+  type        = bool
+  default     = false
+  description = "Wheter to use HTTP trigger instead of the event trigger."
 }
 
 variable "labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "event_trigger" {
 
 variable "trigger_http" {
   type        = bool
-  default     = false
+  default     = null
   description = "Wheter to use HTTP trigger instead of the event trigger."
 }
 


### PR DESCRIPTION
This PR is adding an extra input called `trigger_http` which allows to create a function which is triggered by any HTTP request. This makes the previously required input `event_trigger` optional as only one of them can be used at a time.