### PR TITLE
Add Serverless VPC Connector support for the Cloud Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ module "localhost_function" {
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | object | `<list>` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | string | n/a | yes |
 | timeout\_s | The amount of time in seconds allotted for the execution of the function. | number | `"60"` | no |
+| vpc\_connector | The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is projects/*/locations/*/connectors/*. | string | `"null"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ resource "google_cloudfunctions_function" "main" {
   timeout             = var.timeout_s
   entry_point         = var.entry_point
   ingress_settings    = var.ingress_settings
+  vpc_connector       = var.vpc_connector
 
   event_trigger {
     event_type = var.event_trigger["event_type"]

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "ingress_settings" {
   default     = "ALLOW_ALL"
   description = "The ingress settings for the function"
 }
+
+variable "vpc_connector" {
+  type        = string
+  default     = null
+  description = "The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is projects/*/locations/*/connectors/*."
+}


### PR DESCRIPTION
Adding `vpc_connector` support for the Cloud Function. This should resolve #55 

