### PR TITLE
Adds optional input 'max_instances'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module "localhost_function" {
 | event\_trigger\_failure\_policy\_retry | A toggle to determine if the function should be retried on failure. | bool | `"false"` | no |
 | ingress\_settings | The ingress settings for the function | string | `"ALLOW_ALL"` | no |
 | labels | A set of key/value label pairs to assign to the Cloud Function. | map(string) | `<map>` | no |
+| max\_instances | The maximum number of parallel executions of the function. | number | `"0"` | no |
 | name | The name to apply to any nameable resources. | string | n/a | yes |
 | project\_id | The ID of the project to which resources will be applied. | string | n/a | yes |
 | region | The region in which resources will be applied. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ data "null_data_source" "wait_for_files" {
 data "archive_file" "main" {
   type        = "zip"
   output_path = pathexpand("${var.source_directory}.zip")
-  source_dir  = "${data.null_data_source.wait_for_files.outputs["source_dir"]}"
+  source_dir  = data.null_data_source.wait_for_files.outputs["source_dir"]
 }
 
 resource "google_storage_bucket" "main" {
@@ -71,6 +71,7 @@ resource "google_cloudfunctions_function" "main" {
   name                = var.name
   description         = var.description
   available_memory_mb = var.available_memory_mb
+  max_instances       = var.max_instances
   timeout             = var.timeout_s
   entry_point         = var.entry_point
   ingress_settings    = var.ingress_settings

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "timeout_s" {
   description = "The amount of time in seconds allotted for the execution of the function."
 }
 
+variable "max_instances" {
+  type        = number
+  default     = 0
+  description = "The maximum number of parallel executions of the function."
+}
+
 variable "bucket_labels" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
1. Exposes max_instances on the google_cloudfunctions_function.
- Defaulted to 0, resulting in a noop for existing instances where the input is omitted.
- Setting is useful for resolving API or application throttling issues due to high execution rates.

2. Corrects string substitution syntax, deprecated in terraform 0.13+
3. Updates docs.
