### PR TITLE
Add support for using secret manager environment variables in Cloud Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ module "localhost_function" {
 | project\_id | The ID of the project to which resources will be applied. | `string` | n/a | yes |
 | region | The region in which resources will be applied. | `string` | n/a | yes |
 | runtime | The runtime in which the function will be executed. | `string` | n/a | yes |
-| secret\_environment\_variables | A list of maps which contains key, project\_id (only project number is supported by this field), secret\_id (not the full secret name) and version to assign to the function as a set of secret environment variables. | `list(map(string))` | `[]` | no |
+| secret\_environment\_variables | A list of maps which contains key, project\_id, secret\_name (not the full secret id) and version to assign to the function as a set of secret environment variables. | `list(map(string))` | `[]` | no |
 | service\_account\_email | The service account to run the function as. | `string` | `""` | no |
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | <pre>list(object({<br>    filename = string<br>    id       = string<br>  }))</pre> | `[]` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module "localhost_function" {
 | project\_id | The ID of the project to which resources will be applied. | `string` | n/a | yes |
 | region | The region in which resources will be applied. | `string` | n/a | yes |
 | runtime | The runtime in which the function will be executed. | `string` | n/a | yes |
+| secret\_environment\_variables | A list of maps which contains key, project\_id (only project number is supported by this field), secret\_id (not the full secret name) and version to assign to the function as a set of secret environment variables. | `list(map(string))` | `[]` | no |
 | service\_account\_email | The service account to run the function as. | `string` | `""` | no |
 | source\_dependent\_files | A list of any Terraform created `local_file`s that the module will wait for before creating the archive. | <pre>list(object({<br>    filename = string<br>    id       = string<br>  }))</pre> | `[]` | no |
 | source\_directory | The pathname of the directory which contains the function source code. | `string` | n/a | yes |
@@ -111,6 +112,7 @@ the following IAM roles:
 
 - Cloud Functions Developer: `roles/cloudfunctions.developer`
 - Storage Admin: `roles/storage.admin`
+- Secret Manager Accessor: `roles/secretmanager.secretAccessor`
 
 ### APIs
 
@@ -119,6 +121,7 @@ following APIs enabled:
 
 - Cloud Functions API: `cloudfunctions.googleapis.com`
 - Cloud Storage API: `storage-component.googleapis.com`
+- Secret Manager API: `secretmanager.googleapis.com`
 
 The [Project Factory module][project-factory-module-site] can be used to
 provision projects with specific APIs activated.

--- a/examples/dynamic-files/README.md
+++ b/examples/dynamic-files/README.md
@@ -2,7 +2,8 @@
 
 This example demonstrates how to use the
 [root module][root-module] that will contain source
-code files generated from Terraform itself.
+code files generated from Terraform itself and
+environment variable stored in the Secrets Manager.
 
 ## Usage
 
@@ -29,6 +30,7 @@ this directory:
 | function\_name | The name of the function created |
 | project\_id | The project in which resources are applied. |
 | random\_file\_string | The content of the terraform created file in the source directory. |
+| random\_secret\_string | The value of the secret variable. |
 | region | The region in which resources are applied. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -46,7 +48,7 @@ must also be met.
 The following software dependencies must be installed on the system
 from which this module will be invoked:
 
-- [Terraform][terraform-site] v0.12
+- [Terraform][terraform-site] v0.13
 
 ### IAM Roles
 
@@ -56,6 +58,7 @@ the following IAM roles:
 - Logs Configuration Writer: `roles/logging.configWriter`
 - Pub/Sub Admin: `roles/pubsub.admin`
 - Service Account User: `roles/iam.serviceAccountUser`
+- Secret Manager Admin: `roles/secretmanager.admin`
 
 - Default AppSpot user: `roles/owner`
 - Your user: `roles/resourcemanager.projectCreator`
@@ -67,6 +70,7 @@ following APIs enabled:
 
 - Cloud Pub/Sub API: `pubsub.googleapis.com`
 - Stackdriver Logging API: `logging.googleapis.com`
+- Secret Manager API: `secretmanager.googleapis.com`
 
 [event-folder-log-entry-submodule-requirements]: ../../modules/event-folder-log-entry/README.md#requirements
 [event-folder-log-entry-submodule]: ../../modules/event-folder-log-entry

--- a/examples/dynamic-files/function_source/index.js
+++ b/examples/dynamic-files/function_source/index.js
@@ -27,9 +27,10 @@ const filePath = path.join(__dirname, "terraform_created_file.txt");
 exports.fileContent = (data, context, callback) => {
   console.log("Received event");
 
+  console.log("Value from KEY env variable: " + process.env.KEY);
   fs.readFile(filePath, { encoding: "utf-8" }, function(err, data) {
     if (!err) {
-      callback(null, data);
+      callback(null, data + "\n" + process.env.KEY);
     } else {
       callback(err);
     }

--- a/examples/dynamic-files/outputs.tf
+++ b/examples/dynamic-files/outputs.tf
@@ -29,7 +29,12 @@ output "function_name" {
   description = "The name of the function created"
 }
 
+output "random_secret_string" {
+  value       = random_string.random[0].result
+  description = "The value of the secret variable."
+}
+
 output "random_file_string" {
-  value       = random_string.random.result
+  value       = random_string.random[1].result
   description = "The content of the terraform created file in the source directory."
 }

--- a/examples/dynamic-files/versions.tf
+++ b/examples/dynamic-files/versions.tf
@@ -18,7 +18,8 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
+      version = ">= 4.11"
     }
     local = {
       source = "hashicorp/local"

--- a/main.tf
+++ b/main.tf
@@ -58,10 +58,6 @@ data "archive_file" "main" {
   excludes    = var.files_to_exclude_in_source_dir
 }
 
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 
 resource "google_storage_bucket" "main" {
   count                       = var.create_bucket ? 1 : 0
@@ -122,8 +118,8 @@ resource "google_cloudfunctions_function" "main" {
 
     content {
       key        = secret_environment_variables.value["key"]
-      project_id = lookup(secret_environment_variables.value, "project_id", data.google_project.project.number)
-      secret     = secret_environment_variables.value["secret_id"]
+      project_id = lookup(secret_environment_variables.value, "project_id", var.project_id)
+      secret     = secret_environment_variables.value["secret_name"]
       version    = lookup(secret_environment_variables.value, "version", "latest")
     }
   }

--- a/test/integration/dynamic-files/dynamic_files_test.go
+++ b/test/integration/dynamic-files/dynamic_files_test.go
@@ -36,14 +36,16 @@ func TestDynamicFiles(t *testing.T) {
 		region := bpt.GetStringOutput("region")
 		functionName := bpt.GetStringOutput("function_name")
 		randomFileString := bpt.GetStringOutput("random_file_string")
+		randomSecretString := bpt.GetStringOutput("random_secret_string")
 
 		// call the function directly
 		op := gcloud.Run(t,
 			fmt.Sprintf("functions call %s", functionName),
 			gcloud.WithCommonArgs([]string{"--data", "{}", "--format", "json", "--project", project, "--region", region}),
 		)
-		// assert random string is contained in function response
-		assert.Contains(op.Get("result").String(), randomFileString, "contains random string")
+		// assert file random string and secret random string is contained in function response
+		assert.Contains(op.Get("result").String(), randomFileString, "contains file random string")
+		assert.Contains(op.Get("result").String(), randomSecretString, "contains secret random string")
 	})
 
 	bpt.Test()

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -23,6 +23,7 @@ locals {
     "roles/logging.configWriter",
     "roles/source.admin",
     "roles/iam.serviceAccountUser",
+    "roles/secretmanager.admin",
   ]
 
   int_required_folder_roles = [

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,11 +32,12 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name              = local.project_name
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                    = local.project_name
+  random_project_id       = true
+  org_id                  = var.org_id
+  folder_id               = var.folder_id
+  billing_account         = var.billing_account
+  default_service_account = "keep"
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -46,7 +46,8 @@ module "project" {
     "cloudfunctions.googleapis.com",
     "storage-component.googleapis.com",
     "sourcerepo.googleapis.com",
-    "compute.googleapis.com"
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "runtime" {
   description = "The runtime in which the function will be executed."
 }
 
+variable "secret_environment_variables" {
+  type        = list(map(string))
+  default     = []
+  description = "A list of maps which contains key, project_id (only project number is supported by this field), secret_id (not the full secret name) and version to assign to the function as a set of secret environment variables."
+}
+
 variable "source_directory" {
   type        = string
   description = "The pathname of the directory which contains the function source code."
@@ -172,4 +178,3 @@ variable "log_object_prefix" {
   default     = null
   description = "Log object prefix"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "runtime" {
 variable "secret_environment_variables" {
   type        = list(map(string))
   default     = []
-  description = "A list of maps which contains key, project_id (only project number is supported by this field), secret_id (not the full secret name) and version to assign to the function as a set of secret environment variables."
+  description = "A list of maps which contains key, project_id, secret_name (not the full secret id) and version to assign to the function as a set of secret environment variables."
 }
 
 variable "source_directory" {

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.11, < 5.0"
     }
   }
 


### PR DESCRIPTION
Hello All,
I would like to add support for using secret manager environment variables to this module.

New variable: `secret_environment_variables`

Supported by Google provider since version 4.11.0
Available for Terraform >= v0.13.0

Example of usage:
```
module "http_function" {
  source  = "terraform-google-modules/event-function/google"
  ...
  secret_environment_variables = [
    {
      key        = "ACCESS_TOKEN"
      project_id = "111111"
      secret     = "SECRET_ACCESS_TOKEN"
    },
    {
      key     = "CLIENT_ID"
      secret  = "SECRET_CLIENT_ID"
      version = "1"
    }
  ]
  ...
}
```