### PR TITLE
fix: use variable to set output file mode on archive file data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module "localhost_function" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| archive\_output\_file\_mode | The file mode of the locally generated archive | `string` | `"0664"` | no |
 | available\_memory\_mb | The amount of memory in megabytes allotted for the function to use. | `number` | `256` | no |
 | bucket\_force\_destroy | When deleting the GCS bucket containing the cloud function, delete all objects in the bucket first. | `bool` | `false` | no |
 | bucket\_labels | A set of key/value label pairs to assign to the function source archive bucket. | `map(string)` | `{}` | no |

--- a/examples/automatic-labelling-folder/versions.tf
+++ b/examples/automatic-labelling-folder/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/automatic-labelling-from-localhost/versions.tf
+++ b/examples/automatic-labelling-from-localhost/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/automatic-labelling-from-repository/versions.tf
+++ b/examples/automatic-labelling-from-repository/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/delete-vms-without-cmek/versions.tf
+++ b/examples/delete-vms-without-cmek/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.0"
+      version = "~> 2.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,11 @@ data "null_data_source" "wait_for_files" {
 }
 
 data "archive_file" "main" {
-  type        = "zip"
-  output_path = pathexpand("${var.source_directory}.zip")
-  source_dir  = data.null_data_source.wait_for_files.outputs["source_dir"]
-  excludes    = var.files_to_exclude_in_source_dir
+  type             = "zip"
+  output_path      = pathexpand("${var.source_directory}.zip")
+  source_dir       = data.null_data_source.wait_for_files.outputs["source_dir"]
+  excludes         = var.files_to_exclude_in_source_dir
+  output_file_mode = var.archive_output_file_mode
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,9 @@ variable "build_environment_variables" {
   default     = {}
   description = "A set of key/value environment variable pairs available during build time."
 }
+
+variable "archive_output_file_mode" {
+  type        = string
+  default     = "0664"
+  description = "The file mode of the locally generated archive"
+}


### PR DESCRIPTION
This is a proposed fix for [issue #105 ](https://github.com/terraform-google-modules/terraform-google-event-function/issues/105).