### PR TITLE
fix: remove gzip content-encoding metadata on function source archive 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,6 @@ resource "google_storage_bucket_object" "main" {
   bucket              = var.create_bucket ? google_storage_bucket.main[0].name : var.bucket_name
   source              = data.archive_file.main.output_path
   content_disposition = "attachment"
-  content_encoding    = "gzip"
   content_type        = "application/zip"
 }
 


### PR DESCRIPTION
The gzip content encoding is not right for a zip archive and does not
actually work. When working with this module, I had to remove the
content-encoding to make things work. Otherwise, I was getting a
"End-of-central-directory signature not found" error in Cloud Build
during function deployment.
    
When I tried to download the archive using my browser, the browser
errored, but gsutil succeeded. The file uploaded to GCS was complete so
that was not the reason for the error. Removing the content-encoding
field fixed the deployment.