### PR TITLE
feat: Add variables and use them in google_cloudfunctions_function resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,15 @@ module "localhost_function" {
 | build\_environment\_variables | A set of key/value environment variable pairs available during build time. | `map(string)` | `{}` | no |
 | create\_bucket | Whether to create a new bucket or use an existing one. If false, `bucket_name` should reference the name of the alternate bucket to use. | `bool` | `true` | no |
 | description | The description of the function. | `string` | `"Processes events."` | no |
+| docker\_registry | Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER\_REGISTRY (default) and ARTIFACT\_REGISTRY. | `string` | `"CONTAINER_REGISTRY"` | no |
+| docker\_repository | User managed repository created in Artifact Registry optionally with a customer managed encryption key. If specified, deployments will use Artifact Registry. | `string` | n/a | yes |
 | entry\_point | The name of a method in the function source which will be invoked when the function is executed. | `string` | n/a | yes |
 | environment\_variables | A set of key/value environment variable pairs to assign to the function. | `map(string)` | `{}` | no |
 | event\_trigger | A source that fires events in response to a condition in another service. | `map(string)` | `{}` | no |
 | event\_trigger\_failure\_policy\_retry | A toggle to determine if the function should be retried on failure. | `bool` | `false` | no |
 | files\_to\_exclude\_in\_source\_dir | Specify files to ignore when reading the source\_dir | `list(string)` | `[]` | no |
 | ingress\_settings | The ingress settings for the function. Allowed values are ALLOW\_ALL, ALLOW\_INTERNAL\_AND\_GCLB and ALLOW\_INTERNAL\_ONLY. Changes to this field will recreate the cloud function. | `string` | `"ALLOW_ALL"` | no |
+| kms\_key\_name | Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt function resources. | `string` | n/a | yes |
 | labels | A set of key/value label pairs to assign to the Cloud Function. | `map(string)` | `{}` | no |
 | log\_bucket | Log bucket | `string` | `null` | no |
 | log\_object\_prefix | Log object prefix | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,6 @@ resource "google_cloudfunctions_function" "main" {
   region                      = var.region
   service_account_email       = var.service_account_email
   build_environment_variables = var.build_environment_variables
-
   docker_registry             = var.docker_registry
   docker_repository           = var.docker_repository
   kms_key_name                = var.kms_key_name

--- a/main.tf
+++ b/main.tf
@@ -144,4 +144,8 @@ resource "google_cloudfunctions_function" "main" {
   region                      = var.region
   service_account_email       = var.service_account_email
   build_environment_variables = var.build_environment_variables
+
+  docker_registry             = var.docker_registry
+  docker_repository           = var.docker_repository
+  kms_key_name                = var.kms_key_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,20 @@ variable "build_environment_variables" {
   default     = {}
   description = "A set of key/value environment variable pairs available during build time."
 }
+
+variable "docker_registry" {
+  type        = string
+  default     = "CONTAINER_REGISTRY"
+  description = "Docker Registry to use for storing the function's Docker images. Allowed values are CONTAINER_REGISTRY (default) and ARTIFACT_REGISTRY."
+}
+
+variable "docker_repository" {
+  type        = string
+  description = "User managed repository created in Artifact Registry optionally with a customer managed encryption key. If specified, deployments will use Artifact Registry."
+}
+
+
+variable "kms_key_name" {
+  type        = string
+  description = "Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt function resources."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -193,11 +193,13 @@ variable "docker_registry" {
 
 variable "docker_repository" {
   type        = string
+  default     = ""
   description = "User managed repository created in Artifact Registry optionally with a customer managed encryption key. If specified, deployments will use Artifact Registry."
 }
 
 
 variable "kms_key_name" {
   type        = string
+  default     = ""
   description = "Resource name of a KMS crypto key (managed by the user) used to encrypt/decrypt function resources."
 }


### PR DESCRIPTION
Variables added docker_registry, docker_repository and kms_key_name This enables storing cloud build container in Artifact Registry

See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function#docker_registry