### PR TITLE
Add support for passing build service account argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ resource "google_cloudfunctions_function" "main" {
   project                     = var.project_id
   region                      = var.region
   service_account_email       = var.service_account_email
+  build_service_account       = var.build_service_account
   build_environment_variables = var.build_environment_variables
   docker_registry             = var.docker_registry
   docker_repository           = var.docker_repository

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "available_memory_mb" {
   description = "The amount of memory in megabytes allotted for the function to use."
 }
 
+variable "build_service_account" {
+  type        = string
+  default     = null
+  description = " The self-provided service account to use to build the function. The format of this value is projects/{project}/serviceAccounts/{serviceAccountEmail}"
+}
+
 variable "description" {
   type        = string
   default     = "Processes events."

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.23, < 7"
+      version = ">= 5.39, < 7"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
This PR adds support for specifying custom Cloud Build service account used by cloud functions in the background.
The custom cloud build function was introduced in Google terraform provider 5.39, hence versions upgrade.

This PR is the same as https://github.com/terraform-google-modules/terraform-google-event-function/pull/245 just with latest changes from upstream