### PR TITLE
Added build_service_account argument for google_cloudfunctions_function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,7 @@ resource "google_cloudfunctions_function" "main" {
   region                      = var.region
   service_account_email       = var.service_account_email
   build_environment_variables = var.build_environment_variables
+  build_service_account       = var.build_service_account
   docker_registry             = var.docker_registry
   docker_repository           = var.docker_repository
   kms_key_name                = var.kms_key_name

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,12 @@ variable "service_account_email" {
   description = "The service account to run the function as."
 }
 
+variable "build_service_account" {
+  type        = string
+  default     = ""
+  description = "The self-provided service account to use to build the function. The format of this field is projects/{project}/serviceAccounts/{serviceAccountEmail}"
+}
+
 variable "bucket_name" {
   type        = string
   default     = ""


### PR DESCRIPTION
Added build_service_account argument for google_cloudfunctions_function to be able to specify the service account for function building process.
Refer to https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function#:~:text=build_service_account%20%2D%20(Optional)%20If%20provided%2C%20the%20self%2Dprovided%20service%20account%20to%20use%20to%20build%20the%20function.%20The%20format%20of%20this%20field%20is%20projects/%7Bproject%7D/serviceAccounts/%7BserviceAccountEmail%7D